### PR TITLE
Fix gallery link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -511,7 +511,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </ul>
 <p>Then explore the small but growing third-party ecosystem of FastHTML tutorials, notebooks, libraries, and components:</p>
 <ul>
-<li><a href="https://fastht.ml/gallery">FastHTML Gallery</a>: Learn from minimal examples of components (ie chat bubbles, click-to-edit, infinite scroll, etc)</li>
+<li><a href="https://gallery.fastht.ml/">FastHTML Gallery</a>: Learn from minimal examples of components (ie chat bubbles, click-to-edit, infinite scroll, etc)</li>
 <li><a href="https://isaac-flath.github.io/website/posts/boots/FasthtmlTutorial.html">Creating Custom FastHTML Tags for Markdown Rendering</a> by Isaac Flath</li>
 <li><a href="https://blog.mariusvach.com/posts/login-fasthtml">How to Build a Simple Login System in FastHTML</a> by Marius Vach</li>
 <li>Your tutorial here!</li>


### PR DESCRIPTION
Front page of FastHTML docs points to a wrong url for FastHTML gallery. This PR adds correct url for the link.